### PR TITLE
Rescue Permutation using NEON Intrinsics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
 DUSE_AVX2 = -DUSE_AVX2=$(or $(AVX2),0)
+DUSE_NEON = -DUSE_NEON=$(or $(NEON),0)
 
 all: testing
 
 test/a.out: test/main.cpp include/*.hpp include/test/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $< -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $(DUSE_NEON) $< -o $@
 
 testing: test/a.out
 	./$<
@@ -21,7 +22,7 @@ format:
 bench/a.out: bench/main.cpp include/*.hpp include/bench/*.hpp
 	# make sure you've google-benchmark globally installed;
 	# see https://github.com/google/benchmark/tree/da652a7#installation
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $< -lbenchmark -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $(DUSE_NEON) $< -lbenchmark -o $@
 
 benchmark: bench/a.out
 	./$< --benchmark_time_unit=ns --benchmark_counters_tabular=true

--- a/README.md
+++ b/README.md
@@ -119,95 +119,239 @@ AVX2=1 make benchmark # benchmarks AVX2 implementation
 ### On Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz ( **Scalar** implementation compiled with GCC )
 
 ```bash
-2022-12-20T12:39:17+00:00
+2022-12-22T15:39:15+00:00
 Running ./bench/a.out
-Run on (128 X 1312.71 MHz CPU s)
+Run on (128 X 2072.24 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x64)
   L1 Instruction 32 KiB (x64)
   L2 Unified 1280 KiB (x64)
   L3 Unified 55296 KiB (x2)
-Load Average: 0.22, 0.11, 0.04
+Load Average: 0.11, 0.04, 0.01
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-bench_rphash::permutation/manual_time      31497 ns        43352 ns        22225       31.7489k/s            36.866k               31.484k            31.359k
-bench_rphash::hash/4/manual_time           32135 ns        36167 ns        21781       31.1185k/s            42.126k               32.123k            32.006k
-bench_rphash::hash/8/manual_time           31813 ns        39758 ns        22003       31.4342k/s            33.936k               31.801k             31.68k
-bench_rphash::hash/16/manual_time          63613 ns        79371 ns        11004         15.72k/s           100.307k               63.586k             63.39k
-bench_rphash::hash/32/manual_time         127225 ns       158622 ns         5502       7.86011k/s           158.618k               127.17k           126.914k
-bench_rphash::hash/64/manual_time         254419 ns       317107 ns         2751       3.93052k/s           268.945k               254.35k           253.972k
-bench_rphash::hash/128/manual_time        508787 ns       634438 ns         1376       1.96546k/s           511.657k              508.659k           508.175k
+bench_rphash::permutation/manual_time      31499 ns        43123 ns        22224       31.7467k/s            33.988k               31.489k            31.363k
+bench_rphash::hash/4/manual_time           32136 ns        36090 ns        21782        31.118k/s            38.102k               32.124k            31.998k
+bench_rphash::hash/8/manual_time           31821 ns        39618 ns        22000        31.426k/s             42.13k               31.806k            31.681k
+bench_rphash::hash/16/manual_time          63608 ns        79070 ns        11005       15.7213k/s            68.194k               63.588k            63.417k
+bench_rphash::hash/32/manual_time         127188 ns       157987 ns         5504        7.8624k/s           129.934k               127.15k           126.867k
+bench_rphash::hash/64/manual_time         254360 ns       315933 ns         2752       3.93144k/s           288.681k              254.272k           253.928k
+bench_rphash::hash/128/manual_time        508638 ns       632906 ns         1376       1.96603k/s            522.51k              508.456k            507.97k
 ```
 
 ### On Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz ( **AVX2** implementation compiled with GCC )
 
 ```bash
-2022-12-20T12:40:12+00:00
+2022-12-22T15:40:04+00:00
 Running ./bench/a.out
-Run on (128 X 800.524 MHz CPU s)
+Run on (128 X 1292.25 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x64)
   L1 Instruction 32 KiB (x64)
   L2 Unified 1280 KiB (x64)
   L3 Unified 55296 KiB (x2)
-Load Average: 0.16, 0.12, 0.04
+Load Average: 0.13, 0.06, 0.01
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-bench_rphash::permutation/manual_time      13741 ns        25476 ns        50939       72.7727k/s            19.977k               13.738k            13.667k
-bench_rphash::hash/4/manual_time           13758 ns        17734 ns        50882       72.6836k/s            19.871k               13.753k             13.67k
-bench_rphash::hash/8/manual_time           13752 ns        21609 ns        50898       72.7189k/s            24.249k               13.747k            13.676k
-bench_rphash::hash/16/manual_time          27480 ns        43095 ns        25472       36.3905k/s             31.38k               27.472k            27.364k
-bench_rphash::hash/32/manual_time          54943 ns        86061 ns        12741       18.2006k/s            64.596k               54.923k            54.779k
-bench_rphash::hash/64/manual_time         109851 ns       172031 ns         6371       9.10323k/s           113.356k              109.824k           109.642k
-bench_rphash::hash/128/manual_time        219686 ns       344632 ns         3186       4.55195k/s           223.527k               219.63k           219.317k
+bench_rphash::permutation/manual_time      13742 ns        25366 ns        50938       72.7718k/s            16.197k               13.738k            13.646k
+bench_rphash::hash/4/manual_time           13756 ns        17694 ns        50886       72.6964k/s            21.138k               13.752k            13.677k
+bench_rphash::hash/8/manual_time           13751 ns        21534 ns        50901       72.7217k/s            16.273k               13.747k            13.669k
+bench_rphash::hash/16/manual_time          27480 ns        42949 ns        25473       36.3899k/s            32.871k               27.473k            27.356k
+bench_rphash::hash/32/manual_time          54944 ns        85784 ns        12740       18.2003k/s            59.909k               54.927k            54.784k
+bench_rphash::hash/64/manual_time         109873 ns       171524 ns         6371       9.10138k/s            185.71k              109.828k           109.609k
+bench_rphash::hash/128/manual_time        219703 ns       344066 ns         3186       4.55159k/s           232.839k              219.643k           219.373k
 ```
 
 ### On Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz ( **Scalar** implementation compiled with Clang )
 
 ```bash
-2022-12-20T12:41:18+00:00
+2022-12-22T15:40:48+00:00
 Running ./bench/a.out
-Run on (128 X 1274.66 MHz CPU s)
+Run on (128 X 1295.09 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x64)
   L1 Instruction 32 KiB (x64)
   L2 Unified 1280 KiB (x64)
   L3 Unified 55296 KiB (x2)
-Load Average: 0.11, 0.12, 0.05
+Load Average: 0.14, 0.08, 0.02
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-bench_rphash::permutation/manual_time      10723 ns        23808 ns        65285       93.2596k/s            17.495k               10.718k            10.636k
-bench_rphash::hash/4/manual_time           10723 ns        15157 ns        65284       93.2552k/s            20.942k                10.72k             10.64k
-bench_rphash::hash/8/manual_time           10725 ns        19487 ns        65275       93.2367k/s            16.557k               10.722k            10.642k
-bench_rphash::hash/16/manual_time          21434 ns        38842 ns        32652       46.6538k/s            30.348k               21.428k            21.317k
-bench_rphash::hash/32/manual_time          42832 ns        77525 ns        16343       23.3468k/s            48.002k               42.819k            42.645k
-bench_rphash::hash/64/manual_time          85622 ns       154866 ns         8175       11.6793k/s                90k               85.596k            85.362k
-bench_rphash::hash/128/manual_time        171201 ns       309544 ns         4089        5.8411k/s           174.509k              171.158k           170.811k
+bench_rphash::permutation/manual_time       9735 ns        22576 ns        71907       102.723k/s            12.152k                9.732k             9.673k
+bench_rphash::hash/4/manual_time            9746 ns        14100 ns        71820       102.606k/s            18.543k                9.742k             9.681k
+bench_rphash::hash/8/manual_time            9749 ns        18356 ns        71795       102.578k/s            11.831k                9.746k             9.681k
+bench_rphash::hash/16/manual_time          19480 ns        36583 ns        35937       51.3342k/s            23.983k               19.474k            19.382k
+bench_rphash::hash/32/manual_time          38931 ns        73003 ns        17979       25.6863k/s            42.868k               38.921k            38.769k
+bench_rphash::hash/64/manual_time          77837 ns       145841 ns         8994       12.8474k/s            81.722k               77.814k            77.656k
+bench_rphash::hash/128/manual_time        155657 ns       291537 ns         4497        6.4244k/s           158.186k              155.614k           155.404k
 ```
 
 ### On Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz ( **AVX2** implementation compiled with Clang )
 
 ```bash
-2022-12-20T12:42:08+00:00
+2022-12-22T15:41:42+00:00
 Running ./bench/a.out
-Run on (128 X 1193.04 MHz CPU s)
+Run on (128 X 2035.27 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x64)
   L1 Instruction 32 KiB (x64)
   L2 Unified 1280 KiB (x64)
   L3 Unified 55296 KiB (x2)
-Load Average: 0.17, 0.14, 0.06
+Load Average: 0.21, 0.11, 0.03
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-bench_rphash::permutation/manual_time       9890 ns        23015 ns        70776       101.114k/s            12.859k                9.887k             9.822k
-bench_rphash::hash/4/manual_time            9900 ns        14329 ns        70708        101.01k/s            90.445k                9.895k             9.818k
-bench_rphash::hash/8/manual_time            9899 ns        18657 ns        70717       101.019k/s            25.879k                9.896k             9.823k
-bench_rphash::hash/16/manual_time          19768 ns        37182 ns        35407       50.5873k/s             23.27k               19.762k            19.648k
-bench_rphash::hash/32/manual_time          39503 ns        74213 ns        17720       25.3145k/s            69.901k               39.491k            39.348k
-bench_rphash::hash/64/manual_time          78971 ns       148260 ns         8865       12.6629k/s            83.093k               78.949k            78.775k
-bench_rphash::hash/128/manual_time        157925 ns       296371 ns         4432       6.33214k/s            183.93k              157.873k           157.635k
+bench_rphash::permutation/manual_time       9603 ns        22470 ns        72890        104.13k/s            17.661k                9.599k             9.527k
+bench_rphash::hash/4/manual_time            9612 ns        13965 ns        72826       104.039k/s            18.814k                9.609k             9.535k
+bench_rphash::hash/8/manual_time            9613 ns        18212 ns        72818       104.024k/s            16.387k                 9.61k             9.532k
+bench_rphash::hash/16/manual_time          19203 ns        36295 ns        36448       52.0739k/s            23.494k               19.198k            19.104k
+bench_rphash::hash/32/manual_time          38372 ns        72446 ns        18242       26.0607k/s            41.034k               38.361k             38.22k
+bench_rphash::hash/64/manual_time          76717 ns       144751 ns         9124       13.0349k/s            80.947k               76.692k            76.503k
+bench_rphash::hash/128/manual_time        153405 ns       289330 ns         4563       6.51869k/s           178.467k              153.358k           153.099k
+```
+
+### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( **Scalar** implementation compiled with Clang )
+
+```bash
+2022-12-22T19:43:28+04:00
+Running ./bench/a.out
+Run on (8 X 2400 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB
+  L1 Instruction 32 KiB
+  L2 Unified 256 KiB (x4)
+  L3 Unified 6144 KiB
+Load Average: 1.19, 2.15, 2.89
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time      11417 ns       137884 ns        61405       87.5911k/s           119.946k               11.218k            11.065k
+bench_rphash::hash/4/manual_time           11567 ns        54524 ns        61425       86.4507k/s            120.79k               11.236k            11.071k
+bench_rphash::hash/8/manual_time           11464 ns        95950 ns        61527        87.228k/s           145.688k               11.236k            11.081k
+bench_rphash::hash/16/manual_time          22696 ns       189947 ns        30847       44.0598k/s           138.261k               22.402k             22.13k
+bench_rphash::hash/32/manual_time          45439 ns       381059 ns        15416       22.0077k/s           191.966k               44.724k            44.247k
+bench_rphash::hash/64/manual_time          91015 ns       763956 ns         7709       10.9872k/s           1.46905M               89.331k            88.494k
+bench_rphash::hash/128/manual_time        188629 ns      1596825 ns         3871       5.30141k/s            435.33k               178.67k           176.944k
+```
+
+### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( **AVX2** implementation compiled with Clang )
+
+```bash
+2022-12-22T19:45:04+04:00
+Running ./bench/a.out
+Run on (8 X 2400 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB
+  L1 Instruction 32 KiB
+  L2 Unified 256 KiB (x4)
+  L3 Unified 6144 KiB
+Load Average: 1.97, 2.11, 2.79
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time       8858 ns       134181 ns        79128       112.898k/s           126.803k                8.722k             8.545k
+bench_rphash::hash/4/manual_time            8874 ns        50963 ns        79380       112.692k/s           123.209k                8.724k              8.55k
+bench_rphash::hash/8/manual_time            8880 ns        92534 ns        79036       112.609k/s            97.469k                8.728k             8.549k
+bench_rphash::hash/16/manual_time          17671 ns       185488 ns        39656         56.59k/s            98.486k               17.376k            17.082k
+bench_rphash::hash/32/manual_time          35122 ns       368258 ns        19880       28.4719k/s           183.345k               34.633k            34.112k
+bench_rphash::hash/64/manual_time          70485 ns       737101 ns        10012       14.1873k/s           4.48529M               69.141k            68.175k
+bench_rphash::hash/128/manual_time        140581 ns      1482180 ns         4985       7.11335k/s           330.147k              138.158k           136.303k
+```
+
+### On ARM Neoverse-V1 aka AWS Graviton3 ( **Scalar** implementation compiled with GCC )
+
+```bash
+2022-12-22T15:48:54+00:00
+Running ./bench/a.out
+Run on (64 X 2100 MHz CPU s)
+CPU Caches:
+  L1 Data 64 KiB (x64)
+  L1 Instruction 64 KiB (x64)
+  L2 Unified 1024 KiB (x64)
+  L3 Unified 32768 KiB (x1)
+Load Average: 0.08, 0.02, 0.01
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time      17051 ns        31612 ns        41058       58.6473k/s            23.325k               17.024k            16.957k
+bench_rphash::hash/4/manual_time           17107 ns        22032 ns        40920       58.4551k/s            27.503k                17.08k            17.013k
+bench_rphash::hash/8/manual_time           17060 ns        26937 ns        41039        58.617k/s            38.753k               17.032k            16.963k
+bench_rphash::hash/16/manual_time          34090 ns        53631 ns        20533       29.3341k/s            45.077k               34.035k            33.944k
+bench_rphash::hash/32/manual_time          68140 ns       107193 ns        10274       14.6757k/s            82.014k               68.029k            67.896k
+bench_rphash::hash/64/manual_time         136230 ns       214227 ns         5138       7.34055k/s           146.935k              136.014k            135.83k
+bench_rphash::hash/128/manual_time        272428 ns       428993 ns         2570        3.6707k/s           283.816k              271.989k           271.714k
+```
+
+### On ARM Neoverse-V1 aka AWS Graviton3 ( **NEON** implementation compiled with GCC )
+
+```bash
+2022-12-22T15:50:11+00:00
+Running ./bench/a.out
+Run on (64 X 2100 MHz CPU s)
+CPU Caches:
+  L1 Data 64 KiB (x64)
+  L1 Instruction 64 KiB (x64)
+  L2 Unified 1024 KiB (x64)
+  L3 Unified 32768 KiB (x1)
+Load Average: 0.15, 0.05, 0.02
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time      17119 ns        31696 ns        40891       58.4156k/s            50.317k               17.092k            17.019k
+bench_rphash::hash/4/manual_time           17236 ns        22195 ns        40606       58.0188k/s            26.107k                17.21k            17.151k
+bench_rphash::hash/8/manual_time           17152 ns        27013 ns        40812       58.3027k/s            40.492k               17.126k            17.056k
+bench_rphash::hash/16/manual_time          34278 ns        53945 ns        20420       29.1735k/s            57.256k               34.225k            34.102k
+bench_rphash::hash/32/manual_time          68511 ns       107882 ns        10215       14.5962k/s            92.947k               68.413k            68.261k
+bench_rphash::hash/64/manual_time         136978 ns       215582 ns         5110       7.30046k/s           143.904k              136.786k           136.576k
+bench_rphash::hash/128/manual_time        273909 ns       431178 ns         2555       3.65085k/s           286.895k              273.525k           273.209k
+```
+
+### On ARM Neoverse-V1 aka AWS Graviton3 ( **Scalar** implementation compiled with Clang )
+
+```bash
+2022-12-22T15:51:07+00:00
+Running ./bench/a.out
+Run on (64 X 2100 MHz CPU s)
+CPU Caches:
+  L1 Data 64 KiB (x64)
+  L1 Instruction 64 KiB (x64)
+  L2 Unified 1024 KiB (x64)
+  L3 Unified 32768 KiB (x1)
+Load Average: 0.13, 0.07, 0.02
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time      17550 ns        32973 ns        39886       56.9786k/s            30.101k               17.521k            17.427k
+bench_rphash::hash/4/manual_time           17560 ns        22696 ns        39864        56.948k/s            40.568k                17.53k             17.43k
+bench_rphash::hash/8/manual_time           17555 ns        27777 ns        39855       56.9635k/s             26.61k               17.527k            17.433k
+bench_rphash::hash/16/manual_time          35088 ns        55486 ns        19950       28.4996k/s            54.669k               35.032k            34.889k
+bench_rphash::hash/32/manual_time          70136 ns       110887 ns         9978        14.258k/s            78.483k               70.023k            69.828k
+bench_rphash::hash/64/manual_time         140230 ns       221700 ns         4992       7.13113k/s           149.666k              140.014k           139.697k
+bench_rphash::hash/128/manual_time        280417 ns       443432 ns         2496       3.56611k/s           286.263k              280.025k           279.561k
+```
+
+### On ARM Neoverse-V1 aka AWS Graviton3 ( **NEON** implementation compiled with Clang )
+
+```bash
+2022-12-22T15:51:50+00:00
+Running ./bench/a.out
+Run on (64 X 2100 MHz CPU s)
+CPU Caches:
+  L1 Data 64 KiB (x64)
+  L1 Instruction 64 KiB (x64)
+  L2 Unified 1024 KiB (x64)
+  L3 Unified 32768 KiB (x1)
+Load Average: 0.15, 0.09, 0.03
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+Benchmark                                      Time             CPU   Iterations items_per_second max_exec_time (ns) median_exec_time (ns) min_exec_time (ns)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+bench_rphash::permutation/manual_time      18277 ns        33684 ns        38300       54.7146k/s            30.028k                18.25k            18.154k
+bench_rphash::hash/4/manual_time           18287 ns        23426 ns        38278       54.6826k/s            25.803k                18.26k            18.169k
+bench_rphash::hash/8/manual_time           18290 ns        28515 ns        38273       54.6752k/s            42.531k               18.262k            18.158k
+bench_rphash::hash/16/manual_time          36553 ns        56968 ns        19150       27.3573k/s            45.235k                 36.5k            36.317k
+bench_rphash::hash/32/manual_time          73058 ns       113815 ns         9581       13.6877k/s             95.43k               72.949k            72.773k
+bench_rphash::hash/64/manual_time         146111 ns       227554 ns         4791       6.84411k/s           156.203k              145.895k           145.631k
+bench_rphash::hash/128/manual_time        292153 ns       455092 ns         2396       3.42286k/s           302.318k              291.729k           291.347k
 ```

--- a/include/ff_neon.hpp
+++ b/include/ff_neon.hpp
@@ -50,10 +50,10 @@ full_mul_u64x2(const uint64x2_t lhs, const uint64x2_t rhs)
   const auto rhs_hi_ = vreinterpretq_u32_u64(vshrq_n_u64(rhs, 32));
   const auto rhs_lo_ = vreinterpretq_u32_u64(vandq_u64(rhs, u32x2));
 
-  const auto lhs_hi = vtrn1_u32(vget_high_u32(lhs_hi_), vget_low_u32(lhs_hi_));
-  const auto lhs_lo = vtrn1_u32(vget_high_u32(lhs_lo_), vget_low_u32(lhs_lo_));
-  const auto rhs_hi = vtrn1_u32(vget_high_u32(rhs_hi_), vget_low_u32(rhs_hi_));
-  const auto rhs_lo = vtrn1_u32(vget_high_u32(rhs_lo_), vget_low_u32(rhs_lo_));
+  const auto lhs_hi = vtrn1_u32(vget_low_u32(lhs_hi_), vget_high_u32(lhs_hi_));
+  const auto lhs_lo = vtrn1_u32(vget_low_u32(lhs_lo_), vget_high_u32(lhs_lo_));
+  const auto rhs_hi = vtrn1_u32(vget_low_u32(rhs_hi_), vget_high_u32(rhs_hi_));
+  const auto rhs_lo = vtrn1_u32(vget_low_u32(rhs_lo_), vget_high_u32(rhs_lo_));
 
   const auto hi = vmull_u32(lhs_hi, rhs_hi);
   const auto mid0 = vmull_u32(lhs_hi, rhs_lo);

--- a/include/ff_neon.hpp
+++ b/include/ff_neon.hpp
@@ -42,6 +42,29 @@ struct ff_neon_t
     v = vld1q_u64(reinterpret_cast<const uint64_t*>(arr));
   }
 
+  // Given two 128 -bit registers, each holding two prime field Z_q elements,
+  // this routine performs element wise addition over Z_q and returns result in
+  // canonical form i.e. each 64 -bit result limb must ∈ Z_q.
+  //
+  // This routine does what
+  // https://github.com/itzmeanjan/rescue-prime/blob/22b7aa5/include/ff.hpp#L73-L84
+  // does, only difference is that instead of working on single element at a
+  // time, it works on two of them.
+  inline ff_neon_t operator+(const ff_neon_t& rhs) const
+  {
+    const auto u64x2 = vdupq_n_u64(UINT64_MAX);
+
+    const auto t0 = vaddq_u64(this->v, rhs.v);
+
+    const auto t1 = vsubq_u64(u64x2, rhs.v);
+    const auto t2 = vcgtq_u64(this->v, t1);
+    const auto t3 = vshrq_n_u64(t2, 32);
+    const auto t4 = vaddq_u64(t0, t3);
+
+    const auto t5 = reduce(t4);
+    return ff_neon_t{ t5 };
+  }
+
   // Stores two prime field Z_q elements ( kept in a 128 -bit register )
   inline void store(ff::ff_t* const arr) const
   {

--- a/include/ff_neon.hpp
+++ b/include/ff_neon.hpp
@@ -7,6 +7,25 @@
 // Prime Field ( i.e. Z_q ) Arithmetic | q = 2^64 - 2^32 + 1
 namespace ff {
 
+// Given a 128 -bit register, holding two 64 -bit unsigned integers, this
+// routine converts each of those two limbs into their canonical representation
+// in prime field Z_q, by reducing using prime modulus Q = 2^64 - 2^32 + 1
+//
+// This routine does exactly what
+// https://github.com/itzmeanjan/rescue-prime/blob/22b7aa5/include/ff.hpp#L62-L64
+// does, but it reduces two field elements at a time.
+static inline uint64x2_t
+reduce(const uint64x2_t a)
+{
+  const auto q = vdupq_n_u64(ff::Q);
+
+  const auto t0 = vcgeq_u64(a, q);
+  const auto t1 = vandq_u64(t0, q);
+  const auto t2 = vsubq_u64(a, t1);
+
+  return t2;
+}
+
 // Two elements of prime field Z_q | q = 2^64 - 2^32 + 1, stored in a 128 -bit
 // Neon register, defining modular {addition, multiplication} over it.
 struct ff_neon_t

--- a/include/ff_neon.hpp
+++ b/include/ff_neon.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#if defined __ARM_NEON
+#include "ff.hpp"
+#include <arm_neon.h>
+
+// Prime Field ( i.e. Z_q ) Arithmetic | q = 2^64 - 2^32 + 1
+namespace ff {
+
+// Two elements of prime field Z_q | q = 2^64 - 2^32 + 1, stored in a 128 -bit
+// Neon register, defining modular {addition, multiplication} over it.
+struct ff_neon_t
+{
+  uint64x2_t v;
+
+  // Assign a 128 -bit register
+  inline constexpr ff_neon_t(const uint64x2_t a) { v = a; }
+
+  // Load two consecutive 64 -bit unsigned integers from memory into a 128 -bit
+  // register.
+  inline ff_neon_t(const ff::ff_t* const arr)
+  {
+    v = vld1q_u64(reinterpret_cast<const uint64_t*>(arr));
+  }
+
+  // Stores two prime field Z_q elements ( kept in a 128 -bit register )
+  inline void store(ff::ff_t* const arr) const
+  {
+    vst1q_u64(reinterpret_cast<uint64_t*>(arr), this->v);
+  }
+};
+
+}
+
+#endif

--- a/include/permutation.hpp
+++ b/include/permutation.hpp
@@ -503,6 +503,22 @@ add_rc0(ff::ff_t* const state, const size_t ridx)
     s2.store(state + off);
   }
 
+#elif defined __ARM_NEON
+
+#if defined __GNUC__
+#pragma GCC unroll 6
+#elif defined __clang__
+#pragma unroll 6
+#endif
+  for (size_t i = 0; i < 6; i++) {
+    const size_t off = i * 2;
+
+    const ff::ff_neon_t s0{ state + off };
+    const ff::ff_neon_t s1{ RC0 + rc_off + off };
+    const auto s2 = s0 + s1;
+    s2.store(state + off);
+  }
+
 #else
 
 #if defined __GNUC__
@@ -542,6 +558,22 @@ add_rc1(ff::ff_t* const state, const size_t ridx)
 
     const ff::ff_avx_t s0{ state + off };
     const ff::ff_avx_t s1{ RC1 + rc_off + off };
+    const auto s2 = s0 + s1;
+    s2.store(state + off);
+  }
+
+#elif defined __ARM_NEON
+
+#if defined __GNUC__
+#pragma GCC unroll 6
+#elif defined __clang__
+#pragma unroll 6
+#endif
+  for (size_t i = 0; i < 6; i++) {
+    const size_t off = i * 2;
+
+    const ff::ff_neon_t s0{ state + off };
+    const ff::ff_neon_t s1{ RC1 + rc_off + off };
     const auto s2 = s0 + s1;
     s2.store(state + off);
   }

--- a/include/permutation.hpp
+++ b/include/permutation.hpp
@@ -326,6 +326,21 @@ apply_sbox(ff::ff_t* const state)
     t1.store(state + off);
   }
 
+#elif defined __ARM_NEON
+
+#if defined __GNUC__
+#pragma GCC unroll 6
+#elif defined __clang__
+#pragma unroll 6
+#endif
+  for (size_t i = 0; i < 6; i++) {
+    const size_t off = i * 2;
+
+    const ff::ff_neon_t t0{ state + off };
+    const auto t1 = exp7(t0);
+    t1.store(state + off);
+  }
+
 #else
 
 #if defined __GNUC__

--- a/include/permutation.hpp
+++ b/include/permutation.hpp
@@ -264,7 +264,9 @@ exp_acc(const ff::ff_t* const base,
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
     for (size_t j = 0; j < STATE_WIDTH; j++) {
       res[j] = res[j] * res[j];
@@ -294,7 +296,9 @@ exp_acc(const ff::ff_t* const base,
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     res[i] = res[i] * tail[i];
@@ -346,7 +350,9 @@ apply_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     state[i] = exp7(state[i]);
@@ -393,7 +399,9 @@ apply_inv_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     t1[i] = state[i] * state[i];
@@ -449,7 +457,9 @@ apply_inv_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     const auto a0 = t7[i] * t7[i];
@@ -498,7 +508,9 @@ add_rc0(ff::ff_t* const state, const size_t ridx)
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     state[i] = state[i] + RC0[rc_off + i];
@@ -539,7 +551,9 @@ add_rc1(ff::ff_t* const state, const size_t ridx)
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     state[i] = state[i] + RC1[rc_off + i];
@@ -676,13 +690,18 @@ apply_mds(ff::ff_t* const state)
 
 #else
 
+#if defined __clang__
+#pragma clang loop unroll(enable)
+#endif
   for (size_t i = 0; i < STATE_WIDTH; i++) {
     const size_t off = i * STATE_WIDTH;
 
 #if defined __GNUC__
 #pragma GCC unroll 12
 #elif defined __clang__
-#pragma unroll 12
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#pragma clang loop interleave(enable)
 #endif
     for (size_t j = 0; j < STATE_WIDTH; j++) {
       tmp[i] = tmp[i] + state[j] * MDS[off + j];

--- a/include/permutation.hpp
+++ b/include/permutation.hpp
@@ -249,7 +249,7 @@ exp_acc(const ff::ff_t* const base,
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
     for (size_t j = 0; j < 3; j++) {
       const size_t off = j * 4;
@@ -280,7 +280,7 @@ exp_acc(const ff::ff_t* const base,
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -320,7 +320,7 @@ apply_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -381,7 +381,7 @@ apply_inv_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -430,7 +430,7 @@ apply_inv_sbox(ff::ff_t* const state)
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -492,7 +492,7 @@ add_rc0(ff::ff_t* const state, const size_t ridx)
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -551,7 +551,7 @@ add_rc1(ff::ff_t* const state, const size_t ridx)
 #if defined __GNUC__
 #pragma GCC unroll 3
 #elif defined __clang__
-#pragma unroll 3
+#pragma clang loop unroll(enable)
 #endif
   for (size_t i = 0; i < 3; i++) {
     const size_t off = i * 4;
@@ -636,6 +636,9 @@ apply_mds(ff::ff_t* const state)
 
 #if defined __AVX2__ && USE_AVX2 != 0
 
+#if defined __clang__
+#pragma clang loop unroll(enable)
+#endif
   for (size_t i = 0; i < 3; i++) {
     const size_t soff = i * 4;
 

--- a/include/permutation.hpp
+++ b/include/permutation.hpp
@@ -7,7 +7,7 @@
 #pragma message("Using AVX2 for Rescue permutation")
 #include "ff_avx.hpp"
 
-#elif defined __ARM_NEON
+#elif defined __ARM_NEON && USE_NEON != 0
 
 #pragma message("Using NEON for Rescue permutation")
 #include "ff_neon.hpp"
@@ -188,7 +188,7 @@ exp7(const ff::ff_avx_t v)
   return v7;
 }
 
-#elif defined __ARM_NEON
+#elif defined __ARM_NEON && USE_NEON != 0
 
 // Uses NEON vector instrinsics for raising two elements ∈ Z_q to their 7-th
 // power, by using less multiplications, than one would do if done using
@@ -330,7 +330,7 @@ apply_sbox(ff::ff_t* const state)
     t1.store(state + off);
   }
 
-#elif defined __ARM_NEON
+#elif defined __ARM_NEON && USE_NEON != 0
 
 #if defined __GNUC__
 #pragma GCC unroll 6
@@ -503,7 +503,7 @@ add_rc0(ff::ff_t* const state, const size_t ridx)
     s2.store(state + off);
   }
 
-#elif defined __ARM_NEON
+#elif defined __ARM_NEON && USE_NEON != 0
 
 #if defined __GNUC__
 #pragma GCC unroll 6
@@ -562,7 +562,7 @@ add_rc1(ff::ff_t* const state, const size_t ridx)
     s2.store(state + off);
   }
 
-#elif defined __ARM_NEON
+#elif defined __ARM_NEON && USE_NEON != 0
 
 #if defined __GNUC__
 #pragma GCC unroll 6

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -162,8 +162,9 @@ test_avx_full_mul()
   }
 }
 
-// Test that vectorized modulo multiplication over Z_q is implemented correctly
-// by checking computed values against scalar implementation.
+// Test that vectorized ( using AVX2 ) modulo multiplication over Z_q is
+// implemented correctly by checking computed values against scalar
+// implementation.
 template<const size_t rounds = 256ul>
 void
 test_avx_mod_mul()
@@ -328,6 +329,51 @@ test_neon_full_mul()
 
     assert(computed_res_lo[off + 0] == expected_res_lo[off + 1]);
     assert(computed_res_lo[off + 1] == expected_res_lo[off + 0]);
+  }
+}
+
+// Test that vectorized ( using NEON intrinsics ) modulo multiplication over Z_q
+// is implemented correctly by checking computed values against scalar
+// implementation.
+template<const size_t rounds = 256ul>
+void
+test_neon_mod_mul()
+{
+  static_assert(rounds > 0, "Round must not be = 0 !");
+
+  alignas(32) ff::ff_t arr0[2 * rounds];
+  alignas(32) ff::ff_t arr1[2 * rounds];
+  alignas(32) ff::ff_t computed_res[2 * rounds];
+  alignas(32) ff::ff_t expected_res[2 * rounds];
+
+  // generate some random Z_q elements
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    arr0[i] = ff::ff_t::random();
+    arr1[i] = ff::ff_t::random();
+  }
+
+  // compute modulo multiplication over Z_q, using scalar implementation
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    expected_res[i] = arr0[i] * arr1[i];
+  }
+
+  // compute modulo multiplication over Z_q, using NEON implementation
+  for (size_t i = 0; i < rounds; i++) {
+    const size_t off = i * 2;
+
+    const ff::ff_neon_t a{ arr0 + off };
+    const ff::ff_neon_t b{ arr1 + off };
+
+    const ff::ff_neon_t c = a * b;
+    c.store(computed_res + off);
+  }
+
+  // finally ensure both implementations produce same result.
+  for (size_t i = 0; i < rounds; i++) {
+    const size_t off = i * 2;
+
+    assert(computed_res[off + 0] == expected_res[off + 1]);
+    assert(computed_res[off + 1] == expected_res[off + 0]);
   }
 }
 

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -204,4 +204,50 @@ test_avx_mod_mul()
 
 #endif
 
+#if defined __ARM_NEON
+
+// Test that vectorized ( using NEON intrinsics ) modulo addition over Z_q is
+// implemented correctly by checking computed values against scalar
+// implementation.
+template<const size_t rounds = 256ul>
+void
+test_neon_mod_add()
+{
+  static_assert(rounds > 0, "Round must not be = 0 !");
+
+  alignas(32) ff::ff_t arr0[2 * rounds];
+  alignas(32) ff::ff_t arr1[2 * rounds];
+  alignas(32) ff::ff_t computed_res[2 * rounds];
+  alignas(32) ff::ff_t expected_res[2 * rounds];
+
+  // generate some random Z_q elements
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    arr0[i] = ff::ff_t::random();
+    arr1[i] = ff::ff_t::random();
+  }
+
+  // compute modulo addition over Z_q, using scalar implementation
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    expected_res[i] = arr0[i] + arr1[i];
+  }
+
+  // compute modulo addition over Z_q, using NEON implementation
+  for (size_t i = 0; i < rounds; i++) {
+    const size_t off = i * 2;
+
+    const ff::ff_neon_t a{ arr0 + off };
+    const ff::ff_neon_t b{ arr1 + off };
+
+    const auto c = a + b;
+    c.store(computed_res + off);
+  }
+
+  // finally ensure both implementations produce same result.
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    assert(computed_res[i] == expected_res[i]);
+  }
+}
+
+#endif
+
 }

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -300,35 +300,9 @@ test_neon_full_mul()
   }
 
   // finally ensure both implementations produce same result.
-  //
-  // Following assertions are written that way because of how NEON intrinsics
-  // load data from memory place them on register. For example
-  //
-  // Assume we're working with following array
-  //
-  // const uint64_t data[2]{0, 1};
-  //
-  // That array can be used for constructing a 128 -bit NEON register with two
-  // 64 -bit limbs, by issuing
-  //
-  // const uint64x2_t reg = vld1q_u64(data);
-  //
-  // If one inspects how that data is laid on 128 -bit register, it'll look like
-  //
-  // |<------ data[1] ------->|<----- data[0] ----->|
-  // |<--- high 64 -bits --->|<--- low 64 -bits --->|
-  // |<--------- 128 -bit NEON register ----------->|
-  //
-  // Which reverses order of array elements on 128 -bit register ( i.e. reg ),
-  // so result computed by `ff::full_mul_u64x2` routine is also flipped.
-  for (size_t i = 0; i < rounds; i++) {
-    const size_t off = i * 2;
-
-    assert(computed_res_hi[off + 0] == expected_res_hi[off + 1]);
-    assert(computed_res_hi[off + 1] == expected_res_hi[off + 0]);
-
-    assert(computed_res_lo[off + 0] == expected_res_lo[off + 1]);
-    assert(computed_res_lo[off + 1] == expected_res_lo[off + 0]);
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    assert(computed_res_hi[i] == expected_res_hi[i]);
+    assert(computed_res_lo[i] == expected_res_lo[i]);
   }
 }
 
@@ -369,11 +343,8 @@ test_neon_mod_mul()
   }
 
   // finally ensure both implementations produce same result.
-  for (size_t i = 0; i < rounds; i++) {
-    const size_t off = i * 2;
-
-    assert(computed_res[off + 0] == expected_res[off + 1]);
-    assert(computed_res[off + 1] == expected_res[off + 0]);
+  for (size_t i = 0; i < 2 * rounds; i++) {
+    assert(computed_res[i] == expected_res[i]);
   }
 }
 

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "ff.hpp"
 #include "ff_avx.hpp"
+#include "ff_neon.hpp"
 #include <cassert>
 
 // Test functional correctness of Rescue Prime implementation

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -17,7 +17,7 @@ main()
 
 #endif
 
-#if defined __ARM_NEON
+#if defined __ARM_NEON && USE_NEON != 0
 
   test_rphash::test_neon_mod_add();
   test_rphash::test_neon_full_mul();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,7 @@ main()
 
   test_rphash::test_neon_mod_add();
   test_rphash::test_neon_full_mul();
+  test_rphash::test_neon_mod_mul();
   std::cout << "[test] NEON -based Rescue Prime field arithmetic\n";
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -11,7 +11,7 @@ main()
 #if defined __AVX2__ && USE_AVX2 != 0
 
   test_rphash::test_avx_mod_add();
-  test_rphash::test_u64_full_mul();
+  test_rphash::test_avx_full_mul();
   test_rphash::test_avx_mod_mul();
   std::cout << "[test] AVX2 -based Rescue Prime field arithmetic\n";
 
@@ -20,6 +20,7 @@ main()
 #if defined __ARM_NEON
 
   test_rphash::test_neon_mod_add();
+  test_rphash::test_neon_full_mul();
   std::cout << "[test] NEON -based Rescue Prime field arithmetic\n";
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -13,7 +13,14 @@ main()
   test_rphash::test_avx_mod_add();
   test_rphash::test_u64_full_mul();
   test_rphash::test_avx_mod_mul();
-  std::cout << "[test] Vectorized Rescue Prime field arithmetic\n";
+  std::cout << "[test] AVX2 -based Rescue Prime field arithmetic\n";
+
+#endif
+
+#if defined __ARM_NEON
+
+  test_rphash::test_neon_mod_add();
+  std::cout << "[test] NEON -based Rescue Prime field arithmetic\n";
 
 #endif
 


### PR DESCRIPTION
- [x] Implement modulo addition/ multiplication over Z_q, using NEON intrinsics | q = $2^{64} - 2^{32} + 1$
- [x] Implement Rescue Permutation using NEON intrinsics
- [x] Test functional correctness of that implementation ( compare results against scalar implementation )
- [x] Benchmark NEON implementation & compare performance against baseline ( scalar implementation )

> **Note** ARM NEON intrinsics are documented here https://arm-software.github.io/acle/neon_intrinsics/advsimd.html