### PR TITLE
Modulo Arithmetic over Prime `2^64-2^32 +1`, using AVX512 Intrinsics

### DIFF
--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#if defined __AVX512F__
+#include "ff.hpp"
+#include <immintrin.h>
+
+// Prime Field ( i.e. Z_q ) Arithmetic | q = 2^64 - 2^32 + 1
+namespace ff {
+
+// Eight elements of the prime field Z_q | q = 2^64 - 2^32 + 1, stored in a 512
+// -bit AVX512 register, loaded *only* from 64 -bytes aligned memory address (
+// see constructor ), defining modular {addition, multiplication} over it, used
+// for implementing Rescue permutation.
+struct ff_avx512_t
+{
+  __m512i v;
+
+  // Assign a 512 -bit register
+  inline constexpr ff_avx512_t(const __m512i a) { v = a; }
+
+  // Load eight 64 -bit unsigned integers from memory into a 512 -bit register.
+  //
+  // Ensure that starting memory address is 64 -bytes aligned, otherwise it'll
+  // result in a segmentation fault.
+  inline ff_avx512_t(const ff::ff_t* const arr) { v = _mm512_load_epi64(arr); }
+
+  // Stores eight prime field Z_q elements ( kept in a 512 -bit register ) into
+  // 64 -bytes aligned memory s.t. starting memory address is provided.
+  //
+  // If starting memory address is not aligned to 64 -bytes boundary, it'll
+  // result in a segmentation fault.
+  inline void store(ff::ff_t* const arr) const
+  {
+    _mm512_store_epi64(arr, this->v);
+  }
+};
+
+}
+
+#endif

--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -7,6 +7,21 @@
 // Prime Field ( i.e. Z_q ) Arithmetic | q = 2^64 - 2^32 + 1
 namespace ff {
 
+// Given a 512 -bit register, holding eight 64 -bit unsigned integers, this
+// routine converts each of those eight limbs to their canonical representation
+// in prime field Z_q i.e. returned register holds eight elements ∈ Z_q.
+static inline __m512i
+reduce(const __m512i a)
+{
+  const auto q = _mm512_set1_epi64(ff::Q);
+
+  const auto t0 = _mm512_cmpgt_epu64_mask(a, q);
+  const auto t1 = _mm512_maskz_set1_epi64(t0, ff::Q);
+  const auto t2 = _mm512_sub_epi64(a, t1);
+
+  return t2;
+}
+
 // Eight elements of the prime field Z_q | q = 2^64 - 2^32 + 1, stored in a 512
 // -bit AVX512 register, loaded *only* from 64 -bytes aligned memory address (
 // see constructor ), defining modular {addition, multiplication} over it, used

--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -53,7 +53,7 @@ struct ff_avx512_t
 
     const auto t0 = _mm512_add_epi64(this->v, rhs.v);
     const auto t1 = _mm512_sub_epi64(u64x8, rhs.v);
-    const auto t2 = _mm512_cmpgt_epi64_mask(this->v, t1);
+    const auto t2 = _mm512_cmpgt_epu64_mask(this->v, t1);
     const auto t3 = _mm512_maskz_set1_epi64(t2, UINT32_MAX);
     const auto t4 = _mm512_add_epi64(t0, t3);
 

--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -42,8 +42,8 @@ full_mul_u64x8(const __m512i lhs, const __m512i rhs)
 {
   const auto u32x8 = _mm512_set1_epi64(UINT32_MAX);
 
-  const auto lhs_hi = _mm512_slli_epi64(lhs, 32);
-  const auto rhs_hi = _mm512_slli_epi64(rhs, 32);
+  const auto lhs_hi = _mm512_srli_epi64(lhs, 32);
+  const auto rhs_hi = _mm512_srli_epi64(rhs, 32);
 
   const auto hi = _mm512_mul_epu32(lhs_hi, rhs_hi);
   const auto mid0 = _mm512_mul_epu32(lhs_hi, rhs);

--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -130,7 +130,7 @@ struct ff_avx512_t
     const auto d = _mm512_srli_epi64(res_hi, 32);
 
     const auto t2 = _mm512_sub_epi64(res_lo, d);
-    const auto t3 = _mm512_cmpgt_epi64_mask(d, res_lo);
+    const auto t3 = _mm512_cmpgt_epu64_mask(d, res_lo);
     const auto t4 = _mm512_maskz_set1_epi64(t3, UINT32_MAX);
     const auto t5 = _mm512_sub_epi64(t2, t4);
 
@@ -139,7 +139,7 @@ struct ff_avx512_t
     const auto t8 = _mm512_add_epi64(t5, t7);
 
     const auto t9 = _mm512_sub_epi64(u64x8, t7);
-    const auto t10 = _mm512_cmpgt_epi64_mask(t5, t9);
+    const auto t10 = _mm512_cmpgt_epu64_mask(t5, t9);
     const auto t11 = _mm512_maskz_set1_epi64(t10, UINT32_MAX);
     const auto t12 = _mm512_add_epi64(t8, t11);
 

--- a/include/ff_avx512.hpp
+++ b/include/ff_avx512.hpp
@@ -22,6 +22,56 @@ reduce(const __m512i a)
   return t2;
 }
 
+// Given two 512 -bit registers, each holding eight 64 -bit unsigned integers,
+// this routine performs a full multiplication of each 64 -bit wide limb with
+// corresponding limb on other register, producing a 128 -bit result, which is
+// splitted into high 64 -bits and low 64 -bits, maintained on two different
+// resulting registers.
+//
+// Note, returned 512 -bit register pair holds
+//
+// - high 64 -bits in first register
+// - then low 64 -bits are kept on second register
+//
+// This routine does exactly what
+// https://github.com/itzmeanjan/rescue-prime/blob/22b7aa5/include/ff.hpp#L15-L50
+// does, only difference is that it performs eight of those operations at a
+// time.
+static inline std::pair<__m512i, __m512i>
+full_mul_u64x8(const __m512i lhs, const __m512i rhs)
+{
+  const auto u32x8 = _mm512_set1_epi64(UINT32_MAX);
+
+  const auto lhs_hi = _mm512_slli_epi64(lhs, 32);
+  const auto rhs_hi = _mm512_slli_epi64(rhs, 32);
+
+  const auto hi = _mm512_mul_epu32(lhs_hi, rhs_hi);
+  const auto mid0 = _mm512_mul_epu32(lhs_hi, rhs);
+  const auto mid1 = _mm512_mul_epu32(lhs, rhs_hi);
+  const auto lo = _mm512_mul_epu32(lhs, rhs);
+
+  const auto mid0_hi = _mm512_srli_epi64(mid0, 32);
+  const auto mid0_lo = _mm512_and_si512(mid0, u32x8);
+  const auto mid1_hi = _mm512_srli_epi64(mid1, 32);
+  const auto mid1_lo = _mm512_and_si512(mid1, u32x8);
+
+  const auto t0 = _mm512_srli_epi64(lo, 32);
+  const auto t1 = _mm512_add_epi64(t0, mid0_lo);
+  const auto t2 = _mm512_add_epi64(t1, mid1_lo);
+  const auto carry = _mm512_srli_epi64(t2, 32);
+
+  const auto t3 = _mm512_add_epi64(hi, mid0_hi);
+  const auto t4 = _mm512_add_epi64(t3, mid1_hi);
+  const auto res_hi = _mm512_add_epi64(t4, carry);
+
+  const auto t5 = _mm512_slli_epi64(mid0_lo, 32);
+  const auto t6 = _mm512_slli_epi64(mid1_lo, 32);
+  const auto t7 = _mm512_add_epi64(lo, t5);
+  const auto res_lo = _mm512_add_epi64(t7, t6);
+
+  return std::make_pair(res_hi, res_lo);
+}
+
 // Eight elements of the prime field Z_q | q = 2^64 - 2^32 + 1, stored in a 512
 // -bit AVX512 register, loaded *only* from 64 -bytes aligned memory address (
 // see constructor ), defining modular {addition, multiplication} over it, used

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -350,4 +350,49 @@ test_neon_mod_mul()
 
 #endif
 
+#if defined __AVX512F__
+
+// Test that vectorized ( using AVX512 ) modulo addition over Z_q is implemented
+// correctly by checking computed values against scalar implementation.
+template<const size_t rounds = 256ul>
+void
+test_avx512_mod_add()
+{
+  static_assert(rounds > 0, "Round must not be = 0 !");
+
+  alignas(64) ff::ff_t arr0[8 * rounds];
+  alignas(64) ff::ff_t arr1[8 * rounds];
+  alignas(64) ff::ff_t computed_res[8 * rounds];
+  alignas(64) ff::ff_t expected_res[8 * rounds];
+
+  // generate some random Z_q elements
+  for (size_t i = 0; i < 8 * rounds; i++) {
+    arr0[i] = ff::ff_t::random();
+    arr1[i] = ff::ff_t::random();
+  }
+
+  // compute modulo addition over Z_q, using scalar implementation
+  for (size_t i = 0; i < 8 * rounds; i++) {
+    expected_res[i] = arr0[i] + arr1[i];
+  }
+
+  // compute modulo addition over Z_q, using AVX512 implementation
+  for (size_t i = 0; i < rounds; i++) {
+    const size_t off = i * 8;
+
+    const ff::ff_avx512_t a{ arr0 + off };
+    const ff::ff_avx512_t b{ arr1 + off };
+
+    const ff::ff_avx512_t c = a + b;
+    c.store(computed_res + off);
+  }
+
+  // finally ensure both implementations produce same result.
+  for (size_t i = 0; i < 8 * rounds; i++) {
+    assert(computed_res[i] == expected_res[i]);
+  }
+}
+
+#endif
+
 }

--- a/include/test/test_ff.hpp
+++ b/include/test/test_ff.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "ff.hpp"
 #include "ff_avx.hpp"
+#include "ff_avx512.hpp"
 #include "ff_neon.hpp"
 #include <cassert>
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,7 @@ main()
 
   test_rphash::test_avx512_mod_add();
   test_rphash::test_avx512_full_mul();
+  test_rphash::test_avx512_mod_mul();
   std::cout << "[test] AVX512 -based Rescue Prime field arithmetic\n";
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -20,6 +20,7 @@ main()
 #if defined __AVX512F__
 
   test_rphash::test_avx512_mod_add();
+  test_rphash::test_avx512_full_mul();
   std::cout << "[test] AVX512 -based Rescue Prime field arithmetic\n";
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -17,6 +17,13 @@ main()
 
 #endif
 
+#if defined __AVX512F__
+
+  test_rphash::test_avx512_mod_add();
+  std::cout << "[test] AVX512 -based Rescue Prime field arithmetic\n";
+
+#endif
+
 #if defined __ARM_NEON && USE_NEON != 0
 
   test_rphash::test_neon_mod_add();


### PR DESCRIPTION
- [x] Modulo Addition over Z_q
- [x] Modulo Multiplication over Z_q
- [x] Ensure functional correctness i.e. compare against scalar implementation 

s.t. these two operations can be used for implementing Rescue Permutation, using AVX512. 